### PR TITLE
Add support for HTML-like labels

### DIFF
--- a/Text/Dot.hs
+++ b/Text/Dot.hs
@@ -157,7 +157,10 @@ showAttrs xs = "[" ++ showAttrs' xs ++ "]"
         showAttrs' (a:as) = showAttr a ++ "," ++ showAttrs' as
 
 showAttr :: (String, String) -> String
-showAttr (name,val) = name ++ "=\""   ++ foldr showsDotChar "" val ++ "\""
+-- Enclose HTML-like label strings in <...>
+showAttr (name@"label",val@('<':_)) = name ++ "=<" ++ foldr showsDotChar "" val ++ ">"
+showAttr (name@"label",('\\':val@('<':_))) = showAttr (name,val)
+showAttr (name,val) = name ++ "=\"" ++ foldr showsDotChar "" val ++ "\""
 
 showsDotChar :: Char -> ShowS
 showsDotChar '"'  = ("\\\"" ++)

--- a/Text/Dot.hs
+++ b/Text/Dot.hs
@@ -158,7 +158,7 @@ showAttrs xs = "[" ++ showAttrs' xs ++ "]"
 
 showAttr :: (String, String) -> String
 -- Enclose HTML-like label strings in <...>
-showAttr (name@"label",val@('<':_)) = name ++ "=<" ++ foldr showsDotChar "" val ++ ">"
+showAttr (name@"label",val@('<':_)) = name ++ "=<" ++ foldr showLitChar "" val ++ ">"
 showAttr (name@"label",('\\':val@('<':_))) = showAttr (name,val)
 showAttr (name,val) = name ++ "=\"" ++ foldr showsDotChar "" val ++ "\""
 


### PR DESCRIPTION
It would be nice to have support for [HTML-like labels](http://www.graphviz.org/doc/info/shapes.html#html). Currently these are not generated correctly, because label strings are always enclosed in `"` in the output.

AFAICS the simplest solution is to check in `showAttr` whether the key is `label` and the value starts with `<` and if true, interpret the label string as an HTML string, i.e. enclose it in `<` instead of `"`. Literal strings can escape the special character with `\<`.

Of course this change will break current uses of the library where a label string starts with `<`.
