### PR TITLE
support non-ascii characters as well

### DIFF
--- a/Text/Dot.hs
+++ b/Text/Dot.hs
@@ -162,7 +162,9 @@ showAttr (name,val) = name ++ "=\""   ++ foldr showsDotChar "" val ++ "\""
 showsDotChar :: Char -> ShowS
 showsDotChar '"'  = ("\\\"" ++)
 showsDotChar '\\' = ("\\\\" ++)
-showsDotChar x    = showLitChar x
+showsDotChar x
+  | isPrint x     = showChar x
+  | otherwise     = showLitChar x
 
 
 -- | 'netlistGraph' generates a simple graph from a netlist.

--- a/test/DotTest.hs
+++ b/test/DotTest.hs
@@ -94,5 +94,7 @@ main = putStrLn $ showDot $ do
                      (\ a -> [succ a `mod` 10,pred a `mod` 10])
                      [ (n,n) | n <- [0..9] :: [Int] ]
                      
+        _ <- box "touché"
+        _ <- box "eight characters: кирилица"
         
         return ()


### PR DESCRIPTION
`showLitChar` is unnecessary restrictive about characters that it wants to quote

I've added a test of latin1 and Unicode characters that should've been rendered like this:
![correct rendering](https://user-images.githubusercontent.com/118058/84701678-557fc180-af4d-11ea-81d4-0caf17b7a2ed.png)

Instead, I've got:
```
n34[shape="box",style="rounded",label="touch\233"];
n35[shape="box",style="rounded",label="\1082\1080\1088\1080\1083\1080\1094\1072"];
```

Fix from this PR allows all the printable characters through, unquoted:
```
n34[shape="box",style="rounded",label="touché"];
n35[shape="box",style="rounded",label="кирилица"];
```